### PR TITLE
Update action.yml - set cache@4.0.1

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -4,7 +4,7 @@ description: Cache metanorma-related assets (fonts, workgroups)
 runs:
   using: "composite"
   steps:
-    - uses: actions/cache@v4.0.1
+    - uses: actions/cache@v4
       with:
         path: |
           ~/.metanorma
@@ -12,7 +12,7 @@ runs:
         key: metanorma-home
         restore-keys: metanorma-home
 
-    - uses: actions/cache@v4.0.1
+    - uses: actions/cache@v4
       with:
         path: |
           ~/.relaton
@@ -20,7 +20,7 @@ runs:
         key: metanorma-relaton
         restore-keys: metanorma-relaton
 
-    - uses: actions/cache@v4.0.1
+    - uses: actions/cache@v4
       with:
         path: |
           ~/.fontist
@@ -29,7 +29,7 @@ runs:
         key: metanorma-fontist
         restore-keys: metanorma-fontist
 
-    - uses: actions/cache@v4.0.1
+    - uses: actions/cache@v4
       with:
         path: ~/.metanorma-ietf-workgroup-cache.json
         key: metanorma-ietf-workgroup-cache

--- a/action.yml
+++ b/action.yml
@@ -4,7 +4,7 @@ description: Cache metanorma-related assets (fonts, workgroups)
 runs:
   using: "composite"
   steps:
-    - uses: actions/cache@v3
+    - uses: actions/cache@v4.0.1
       with:
         path: |
           ~/.metanorma
@@ -12,7 +12,7 @@ runs:
         key: metanorma-home
         restore-keys: metanorma-home
 
-    - uses: actions/cache@v3
+    - uses: actions/cache@v4.0.1
       with:
         path: |
           ~/.relaton
@@ -20,7 +20,7 @@ runs:
         key: metanorma-relaton
         restore-keys: metanorma-relaton
 
-    - uses: actions/cache@v3
+    - uses: actions/cache@v4.0.1
       with:
         path: |
           ~/.fontist
@@ -29,7 +29,7 @@ runs:
         key: metanorma-fontist
         restore-keys: metanorma-fontist
 
-    - uses: actions/cache@v3
+    - uses: actions/cache@v4.0.1
       with:
         path: ~/.metanorma-ietf-workgroup-cache.json
         key: metanorma-ietf-workgroup-cache


### PR DESCRIPTION
Per error message attempting to use actions-mn/cache:

Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/cache@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.