### PR TITLE
feat: support cache site directory after build actions-mn/build-and-publish#16

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,25 +26,32 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest, windows-latest, macos-latest ]
+        samples: [ metanorma/mn-samples-cc ]
+        with:
+        - cache-site-for-manifest: ''
+        - cache-site-for-manifest: test/metanorma/mn-samples-cc/metanorma.yml
     steps:
     - uses: actions/checkout@v4
 
     - uses: actions/checkout@v4
       with:
-        repository: metanorma/mn-samples-cc
-        path: cc
+        repository: ${{ matrix.samples }}
+        path: test/${{ matrix.samples }}
 
     - uses: actions-mn/setup@main
 
     - uses: ./
+      with:
+        cache-site-for-manifest: ${{ matrix.with.cache-site-for-manifest }}
 
     - uses: actions-mn/site-gen@main
       with:
-        source-path: cc
+        source-path: test/${{ matrix.samples }}
         config-file: metanorma.yml
         agree-to-terms: true
+        output-dir: site
 
     - uses: andstor/file-existence-action@v2
       with:
-        files: cc/site/index.html
+        files: test/${{ matrix.samples }}/site/index.html
 

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,16 @@
 name: metanorma-cache
 description: Cache metanorma-related assets (fonts, workgroups)
+inputs:
+  cache-site-for-manifest:
+    description: Path to valid metanorma.yml manifest file
+    default: ''
+  cache-site-path:
+    description: Path to the output site directory
+    default: '_site'
+outputs:
+  cache-site-cache-hit:
+    description: "True if valid cache exists"
+    value: ${{ steps.site-cache.outputs.cache-hit }}
 
 runs:
   using: "composite"
@@ -36,3 +47,33 @@ runs:
           /root/.metanorma-ietf-workgroup-cache.json
         key: metanorma-ietf-workgroup-cache
         restore-keys: metanorma-ietf-workgroup-cache
+
+    - if: ${{ inputs.cache-site-for-manifest != '' }}
+      id: build-input-hash
+      uses: actions/github-script@v7
+      env:
+        METANORMA_MANIFEST: ${{ inputs.cache-site-for-manifest }}
+      with:
+        script: |
+          const fs = require('fs');
+          const yaml = require('yaml');
+          const path = require('path');
+
+          const manifestPath = process.env.METANORMA_MANIFEST;
+          const manifestContent = yaml.parse(fs.readFileSync(manifestPath, 'utf8'));
+          const documentPaths = manifestContent.metanorma.source.files || [];
+          const globDirs = [...new Set(documentPaths.map(documentPath => path.dirname(documentPath)).map(documentPath => path.join(documentPath, '**')))];
+
+          console.log('Base directories:', baseDirs);
+          console.log('Input hash:', hashFiles(...globDirs));
+
+          core.setOutput('input-dirs', globDirs);
+          core.setOutput('input-hash', hashFiles(...globDirs));
+
+    - if: ${{ inputs.cache-site-for-manifest != '' }}
+      id: site-cache
+      uses: actions/cache@v4
+      with:
+        path: ${{ inputs.cache-site-path }}
+        key: metanorma-site-cache-${{ steps.build-input-hash.outputs.cache-hit }}
+        restore-keys: metanorma-site-cache-${{ steps.build-input-hash.outputs.cache-hit }}

--- a/action.yml
+++ b/action.yml
@@ -5,7 +5,9 @@ inputs:
     description: Path to valid metanorma.yml manifest file
     default: ''
   extra-input:
-    description: Coma (or line) seprated list of directories that effect metanorma build
+    description: |
+      Coma (or line) seprated list of directories that effect metanorma build.
+      All pathes relative to `cache-site-for-manifest`
     default: ''
   cache-site-path:
     description: Path to the output site directory
@@ -53,7 +55,7 @@ runs:
 
     - if: ${{ inputs.cache-site-for-manifest != '' }}
       shell: bash
-      run: npm install yaml
+      run: npm install yaml @actions/glob
 
     - if: ${{ inputs.cache-site-for-manifest != '' }}
       id: input-hash
@@ -64,28 +66,34 @@ runs:
       with:
         script: |
           const fs = require('fs');
-          const path = require('path');
           const yaml = require('yaml');
+          const path = require('path');
+          const { hashFiles } = require('@actions/glob');
 
           const manifestPath = process.env.METANORMA_MANIFEST;
           const manifestContent = fs.readFileSync(manifestPath, 'utf8');
           const manifest = yaml.parse(manifestContent);
           const documentPaths = manifest.metanorma.source.files || [];
-          const globDirs = new Set(documentPaths
-            .map(documentPath => path.dirname(documentPath))
-            .map(documentPath => path.join(documentPath, '**'))
+          const basePath = path.dirname(manifestPath);
+
+          const matchPatterns = new Set(
+            documentPaths
+              .map(documentPath => path.dirname(documentPath))
+              .map(documentPath => path.join(basePath, documentPath, '**'))
           );
 
-          process.env.METANORMA_EXTRA_INPUT
-            .split(/[\n,]/)
-            .map(input => path.join(input, '**'))
-            .forEach(input => globDirs.add(input));
+          if (process.env.METANORMA_EXTRA_INPUT) {
+            process.env.METANORMA_EXTRA_INPUT.split(/[\n,]/)
+              .forEach(input => matchPatterns.add(path.join(basePath, input)));
+          }
 
-          console.log('Base directories:', globDirs);
-          console.log('Input hash:', hashFiles(...globDirs));
+          matchPatterns.delete('**');
+          const hashPatterns = [...matchPatterns].join('\n');
+          console.log('Input directories:', hashPatterns);
 
-          core.setOutput('input-dirs', globDirs);
-          core.setOutput('input-hash', hashFiles(...globDirs));
+          const inputHash = await hashFiles(hashPatterns);
+          console.log('Input hash:', inputHash);
+          core.setOutput('input-hash', inputHash);
 
     - if: ${{ inputs.cache-site-for-manifest != '' }}
       id: site-cache

--- a/action.yml
+++ b/action.yml
@@ -4,6 +4,9 @@ inputs:
   cache-site-for-manifest:
     description: Path to valid metanorma.yml manifest file
     default: ''
+  extra-input:
+    description: Coma (or line) seprated list of directories that effect metanorma build
+    default: ''
   cache-site-path:
     description: Path to the output site directory
     default: '_site'
@@ -49,22 +52,36 @@ runs:
         restore-keys: metanorma-ietf-workgroup-cache
 
     - if: ${{ inputs.cache-site-for-manifest != '' }}
-      id: build-input-hash
+      shell: bash
+      run: npm install yaml
+
+    - if: ${{ inputs.cache-site-for-manifest != '' }}
+      id: input-hash
       uses: actions/github-script@v7
       env:
         METANORMA_MANIFEST: ${{ inputs.cache-site-for-manifest }}
+        METANORMA_EXTRA_INPUT: ${{ inputs.extra-input }}
       with:
         script: |
           const fs = require('fs');
-          const yaml = require('yaml');
           const path = require('path');
+          const yaml = require('yaml');
 
           const manifestPath = process.env.METANORMA_MANIFEST;
-          const manifestContent = yaml.parse(fs.readFileSync(manifestPath, 'utf8'));
-          const documentPaths = manifestContent.metanorma.source.files || [];
-          const globDirs = [...new Set(documentPaths.map(documentPath => path.dirname(documentPath)).map(documentPath => path.join(documentPath, '**')))];
+          const manifestContent = fs.readFileSync(manifestPath, 'utf8');
+          const manifest = yaml.parse(manifestContent);
+          const documentPaths = manifest.metanorma.source.files || [];
+          const globDirs = new Set(documentPaths
+            .map(documentPath => path.dirname(documentPath))
+            .map(documentPath => path.join(documentPath, '**'))
+          );
 
-          console.log('Base directories:', baseDirs);
+          process.env.METANORMA_EXTRA_INPUT
+            .split(/[\n,]/)
+            .map(input => path.join(input, '**'))
+            .forEach(input => globDirs.add(input));
+
+          console.log('Base directories:', globDirs);
           console.log('Input hash:', hashFiles(...globDirs));
 
           core.setOutput('input-dirs', globDirs);
@@ -75,5 +92,4 @@ runs:
       uses: actions/cache@v4
       with:
         path: ${{ inputs.cache-site-path }}
-        key: metanorma-site-cache-${{ steps.build-input-hash.outputs.cache-hit }}
-        restore-keys: metanorma-site-cache-${{ steps.build-input-hash.outputs.cache-hit }}
+        key: metanorma-site-cache-${{ steps.input-hash.outputs.cache-hit }}


### PR DESCRIPTION
actions-mn/build-and-publish#16

Two new input introduced:
- `cache-site-for-manifest` - path to manifest
- `extra-input` - for additional input that isn't listed in manifest explicitly